### PR TITLE
avoid error when run rake db:rollback, need to define city as string

### DIFF
--- a/db/migrate/20150504004509_remove_city_from_spree_address.rb
+++ b/db/migrate/20150504004509_remove_city_from_spree_address.rb
@@ -1,5 +1,5 @@
 class RemoveCityFromSpreeAddress < ActiveRecord::Migration
   def change
-    remove_column :spree_addresses, :city
+    remove_column :spree_addresses, :city, :string
   end
 end


### PR DESCRIPTION
i got an error when i try to reinstall this gem on my spree,
rake db:rollback error on this migrate file due to no data type given for city column
